### PR TITLE
Limit specialist chat context to last N turns for LLM, refactor /find…

### DIFF
--- a/app/db/mongo.py
+++ b/app/db/mongo.py
@@ -18,6 +18,7 @@ url_ingestions_collection = db.get_collection("url_ingestions")
 kommo_tokens_collection = db.get_collection("kommo_tokens")
 users_collection = db.get_collection("users") 
 conversation_collection = db.get_collection("conversations")
+specialist_history_collection = db.get_collection("specialist_history")
 
 
 

--- a/app/models/specialist_history.py
+++ b/app/models/specialist_history.py
@@ -1,0 +1,13 @@
+# app/models/specialist_history.py
+
+from typing import Optional
+from pydantic import BaseModel
+from datetime import datetime
+
+class SpecialistHistory(BaseModel):
+    user_email: str
+    query: str
+    doctor_name: str
+    timestamp: datetime
+    session_id: Optional[str] = None
+    response: Optional[dict] = None  # <- Add this

--- a/app/services/find_specialist_engine.py
+++ b/app/services/find_specialist_engine.py
@@ -1,57 +1,110 @@
 # app/services/find_specialist_engine.py
+
+from datetime import datetime
+from app.db.mongo import specialist_history_collection
 import re
 import json
-
-def clean_and_parse(raw: str) -> dict:
-    cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw.strip(), flags=re.MULTILINE)
-    cleaned = re.sub(r"`", "", cleaned)
-    try:
-        return json.loads(cleaned)
-    except Exception as e:
-        print("❌ JSON parsing failed in find_specialist_response:", e)
-        print("Raw model output was:", raw)
-        # Raise or return a fallback
-        raise
-
 from openai import OpenAI
 from app.core.config import settings
 from app.services.prompt_templates import FIND_SPECIALIST_PROMPT
 
-client = OpenAI(api_key=settings.OPENAI_API_KEY, base_url=settings.OPENAI_BASE_URL)
+def clean_and_parse(raw: str) -> dict:
+    # Try to extract JSON first
+    match = re.search(r"\{[\s\S]*\}", raw)
+    if match:
+        json_str = match.group(0)
+        try:
+            return json.loads(json_str)
+        except Exception as e:
+            print("❌ JSON in markdown but failed to parse:", e)
+    # If not JSON, treat as text advice and wrap in expected JSON schema
+    print("ℹ️ Received non-JSON, wrapping as fallback JSON.")
+    return {
+        "response_message": raw.strip(),
+        "Name": "",
+        "Specialization": "",
+        "Registration": "",
+        "Image": "https://nudii.com.br/wp-content/uploads/2025/05/placeholder.png",
+        "doctor_description": ""
+    }
 
-def find_specialist_response(user_query: str) -> dict:
+async def save_specialist_history(
+    user_email: str,
+    query: str,
+    doctor_name: str,
+    session_id: str,
+    response: dict
+):
+    entry = {
+        "query": query,
+        "doctor_name": doctor_name,
+        "response": response,
+        "timestamp": datetime.utcnow()
+    }
+    await specialist_history_collection.update_one(
+        {"user_email": user_email, "session_id": session_id},
+        {"$push": {"queries": entry}, "$set": {"last_updated": datetime.utcnow()}},
+        upsert=True
+    )
+
+async def get_recent_specialist_suggestions(user_email: str, max_records=5, session_id: str = None):
+    """
+    Get the last N specialist suggestions for a user and session, sorted by time descending.
+    """
+    session_doc = await specialist_history_collection.find_one(
+        {"user_email": user_email, "session_id": session_id}
+    )
+    if session_doc and "queries" in session_doc:
+        # Return last N turns (most recent last)
+        return session_doc["queries"][-max_records:]
+    return []
+
+async def get_full_specialist_session_history(user_email: str, session_id: str):
+    session_doc = await specialist_history_collection.find_one(
+        {"user_email": user_email, "session_id": session_id}
+    )
+    return session_doc["queries"] if session_doc and "queries" in session_doc else []
+
+
+def is_similar_query(new_query: str, old_query: str) -> bool:
+    """Very basic similarity check; can be replaced with NLP."""
+    # Lowercase and check for simple substring/keyword overlap
+    n = new_query.lower()
+    o = old_query.lower()
+    # You can use fuzzywuzzy or rapidfuzz for more advanced similarity
+    return n == o or (len(n) > 10 and n in o) or (len(o) > 10 and o in n)
+
+client = OpenAI(api_key=settings.OPENAI_API_KEY, base_url=settings.OPENAI_BASE_URL)
+def find_specialist_response(messages: list) -> dict:
     try:
         resp = client.chat.completions.create(
             model="gpt-4.1",
-            messages=[
-                {"role": "system", "content": FIND_SPECIALIST_PROMPT},
-                {"role": "user",   "content": user_query},
-            ],
+            messages=messages,
             temperature=0,
-            max_tokens=512
+            max_tokens=1024
         )
         raw = resp.choices[0].message.content
         try:
             return clean_and_parse(raw)
         except Exception as e:
-            # JSON parse failed—fallback to safe empty doctor
             print("❌ Returning fallback due to JSON parse failure.")
             return {
-                "response_message": "Sorry, there was an issue processing your request.",
-                "Name": "",
-                "Specialization": "",
-                "Registration": "",
-                "Image": "",
-                "doctor_description": ""
-            }
+            "response_message": "Sorry, there was an issue processing your request.",
+            "Name": "",
+            "Specialization": "",
+            "Registration": "",
+            "Image": "https://nudii.com.br/wp-content/uploads/2025/05/placeholder.png",
+            "doctor_description": ""
+        }
+
     except Exception as e:
         print("❌ GPT call failed:", e)
-        # fallback JSON structure
         return {
             "response_message": "Sorry, there was an issue processing your request.",
             "Name": "",
             "Specialization": "",
             "Registration": "",
-            "Image": "",
+            # FIX THIS LINE
+            "Image": "https://nudii.com.br/wp-content/uploads/2025/05/placeholder.png",
             "doctor_description": ""
         }

--- a/app/services/prompt_templates.py
+++ b/app/services/prompt_templates.py
@@ -1,100 +1,4 @@
 # # app/services/prompt_templates.py
-# FIND_SPECIALIST_PROMPT = """
-# ### AVAILABLE SPECIALISTS (use these verbatim; do NOT add or omit any):
-
-# 1. Name: Dr. Alexander Rolim  
-#    Specialization: Coloproctologia  
-#    Registration: CRM-SP: 83270 | RQE: 55787, 115989, 115988  
-#    Image: https://nudii.com.br/wp-content/uploads/2025/05/Carlos-Obregon-Nudii.webp  
-
-# 2. Name: Dr. Rodrigo Barbosa  
-#    Specialization: Gastrocirurgia, Cirurgia Bariátrica e Coloproctologia  
-#    Registration: CRM-SP: 167670 | RQE: 78610  
-#    Image: https://nudii.com.br/wp-content/uploads/2024/07/Rodrigo-Brbosa-Medio-copiar.webp  
-
-# 3. Name: Dra. Sabrina Figueiredo  
-#    Specialization: Gastroenterologia  
-#    Registration: CRM-SP: 203753 | RQE: 99224  
-#    Image: https://nudii.com.br/wp-content/uploads/2024/10/new-Sabrina-Figueiredo-2-Medio-copiar.webp  
-
-# 4. Name: Dr. Talles Renon  
-#    Specialization: Gastroenterologia  
-#    Registration: CRM-SP: 219956 | RQE: 109521  
-#    Image: https://nudii.com.br/wp-content/uploads/2024/07/Talles-Renon-Medio-copiar.webp  
-
-# 5. Name: Dra. Vanessa Prado  
-#    Specialization: Gastrocirurgia e Coloproctologia  
-#    Registration: CRM-SP: 129114 | RQE: 86701  
-#    Image: https://nudii.com.br/wp-content/uploads/2024/07/Vanessa-Prado-Medio-copiar.webp  
-
-# 6. Name: Dr. Alexandre Ferrarri  
-#    Specialization: Coloproctologia  
-#    Registration: CRM-SP: 179945 | RQE: 92807  
-#    Image: https://nudii.com.br/wp-content/uploads/2024/07/Alexandre-Ferrari-Medio-copiar.webp  
-
-# 7. Name: Dra. Charliana Uchôa  
-#    Specialization: Gastroenterologia  
-#    Registration: CRM-SP: 142970 | RQE: 49554, 77431  
-#    Image: https://nudii.com.br/wp-content/uploads/2024/10/Charliana-Uchoa-1-copiar.webp  
-
-# 8. Name: Dra. Christiani Chaves  
-#    Specialization: Nutrição  
-#    Registration: CRM-SP: 19475  
-#    Image: https://nudii.com.br/wp-content/uploads/2024/10/Christiani-Chaves-1-copiar.webp  
-
-# 9. Name: Dra. Natália Queiroz  
-#    Specialization: Gastroenterologia  
-#    Registration: CRM-SP: 132275 | CRM-PR: 47439 | RQE: 33649  
-#    Image: https://nudii.com.br/wp-content/uploads/2024/10/Natalia-Queiroz-2-copiar.webp  
-
-# 10. Name: Dra. Laís Naziozeno  
-#     Specialization: Gastroenterologia  
-#     Registration: CRM-SP: 204969 | RQE: 115836  
-#     Image: https://nudii.com.br/wp-content/uploads/2025/02/Lais-Naziozeno.webp  
-
-# 11. Name: Dr. Vinicius Rocha  
-#     Specialization: Dermatologia  
-#     Registration: CRM-SP: 168567 | RQE: 96847  
-#     Image: https://nudii.com.br/wp-content/uploads/2025/04/Vinicius-Rocha-Nudii-webp.webp  
-
-# 12. Name: Leonårdo Miggiorin  
-#     Specialization: Psicologia  
-#     Registration: CRP-SP: 119637  
-#     Image: https://nudii.com.br/wp-content/uploads/2025/04/Leonardo-Miggiorin-nudii.webp  
-
-# 13. Name: Dr. Erivelton Lopes  
-#     Specialization: Reumatologia  
-#     Registration: CRM-SP: 166408 | RQE: 89517  
-#     Image: https://nudii.com.br/wp-content/uploads/2025/04/Erivelton-Lopes-Nudii.webp  
-
-# 14. Name: Dr. Carlos Obregon  
-#     Specialization: Cirurgia Geral, Cirurgia do Aparelho Digestivo e Coloproctologia  
-#     Registration: CRM-SP: 177864 | RQE: 107012, 107013  
-#     Image: https://nudii.com.br/wp-content/uploads/2025/05/Carlos-Obregon-Nudii.webp  
-
-
-# You are a multi-mode medical assistant. You will receive a user query about health. There are TWO possible behaviors:
-
-# -----------------
-# ## 1) SPECIALIST SUGGESTION MODE  
-# **Trigger:** The user asks things like “who should I see?”, “which specialist…?”, “I need a doctor for…”, “should I see a specialist?”, etc.  
-# **Action:**  
-# - Choose **exactly one** of the 14 available specialists listed above.  
-# - Compose a friendly opening message (`response_message`) that:
-#     - acknowledges the user’s symptoms
-#     - explains why a digestive-health (IBD) specialist is appropriate
-# - **Output strictly ONE JSON object (no markdown, no extra keys), with these six keys in this order:**
-# ```json
-# {
-#   "response_message": "string",
-#   "Name": "string",
-#   "Specialization": "string",
-#   "Registration": "string",
-#   "Image": "string",
-#   "doctor_description": "string"
-# }
-# """
-
 
 FIND_SPECIALIST_PROMPT = """
 ### AVAILABLE SPECIALISTS (use these verbatim; do NOT add or omit any):
@@ -169,25 +73,29 @@ Specialization: General Surgery, Digestive System Surgery, and Coloproctology
 Registration: CRM-SP: 177864 | RQE: 107012, 107013
 Image: https://nudii.com.br/wp-content/uploads/2025/05/Carlos-Obregon-Nudii.webp
 
-You are a multi‐mode medical assistant. You will receive a user query about health. There are two distinct behaviors:
+You are a multi‐mode medical assistant. You will receive a user query about health.
 
-1) SPECIALIST SUGGESTION MODE  
-   **Trigger**: The user asks things like “who should I see?”, “which specialist…?”, “I need a doctor for…”, “should I see a specialist?”, etc.  
-   **Action**:  
-   • Choose **exactly one** of the 14 available specialists listed below.  
-   • Compose a friendly opening message (`response_message`) that:  
-     – Acknowledges the user’s symptoms  
-     – Explains why a digestive‐health (IBD) specialist is appropriate  
-   • Output **exactly one JSON object**, no markdown, no extra keys, with these six keys **in this order**:
-   ```json
-   {
-     "response_message":    string,
-     "Name":                string,
-     "Specialization":      string,
-     "Registration":        string,
-     "Image":               string,
-     "doctor_description":  string
-   }
+- Always use ONLY the specialists provided above. Do not add or invent any.
+- Output must be strictly valid JSON as specified below—never markdown or free text.
+
+### SPECIALIST SUGGESTION MODE  
+Trigger: The user asks things like “who should I see?”, “which specialist…?”, etc.
+
+Action:  
+• Choose exactly one of the available specialists (unless a NOTE instructs otherwise).
+• If a NOTE is appended at the end, never suggest any specialist named in that NOTE. Only suggest them if there are truly no other specialists available.
+• Compose a friendly opening message (`response_message`) that acknowledges the user’s symptoms and explains why the specialist is appropriate.
+• Output exactly one JSON object, no markdown, no extra keys, with these six keys (in this order):
+
+```json
+{
+  "response_message":    string,
+  "Name":                string,
+  "Specialization":      string,
+  "Registration":        string,
+  "Image":               string,
+  "doctor_description":  string
+}
 ---
 
 Use ONLY the above data when in SPECIALIST SUGGESTION MODE.  

--- a/app/services/prompt_templates.py
+++ b/app/services/prompt_templates.py
@@ -1,107 +1,57 @@
 # # app/services/prompt_templates.py
 
 FIND_SPECIALIST_PROMPT = """
-### AVAILABLE SPECIALISTS (use these verbatim; do NOT add or omit any):
+You are a medical AI assistant. You will receive a health-related question from a user, along with a curated list of relevant specialist profiles extracted from our database.
 
-Name: Dr. Alexander Rolim
-Specialization: Coloproctology
-Registration: CRM-SP: 83270 | RQE: 55787, 115989, 115988
-Image: https://nudii.com.br/wp-content/uploads/2025/05/Carlos-Obregon-Nudii.webp
+**Your task:**
+- Carefully review the provided specialist profiles.
+- Select and recommend the **most appropriate specialist** for the user’s needs **from the provided list ONLY**.
+- If a “NOTE” is present instructing you not to repeat certain recommendations, avoid suggesting those specialists unless absolutely no alternative is available.
+- Your reply must be informative, empathetic, and actionable for the user.
+- **You must only answer questions related to healthcare or medical advice. If a user asks a question not related to health, medicine, or specialists, politely decline to answer.**
 
-Name: Dr. Rodrigo Barbosa
-Specialization: Gastrointestinal Surgery, Bariatric Surgery, and Coloproctology
-Registration: CRM-SP: 167670 | RQE: 78610
-Image: https://nudii.com.br/wp-content/uploads/2024/07/Rodrigo-Brbosa-Medio-copiar.webp
+**Instructions for Output:**
+- Output ONLY a single, valid JSON object—never markdown, never plain text, no extra commentary.
+- Your JSON must contain these fields in this exact order:
+  - "response_message": A warm, clear explanation of why the specialist is a good match, referencing the user’s symptoms or request. If the query is not health-related, explain that you can only answer medical questions.
+  - "Name": Full name of the chosen specialist.
+  - "Specialization": The specialist’s field or expertise, as provided.
+  - "Registration": The official registration number or credentials.
+  - "Image": A direct URL to the specialist’s photo (always from the provided data).
+  - "doctor_description": A concise professional background or description (from the provided data).
 
-Name: Dr. Sabrina Figueiredo
-Specialization: Gastroenterology
-Registration: CRM-SP: 203753 | RQE: 99224
-Image: https://nudii.com.br/wp-content/uploads/2024/10/new-Sabrina-Figueiredo-2-Medio-copiar.webp
+**Language Rule:**
+- If the user's query is in English, answer in English. If the user's query is in Portuguese, answer in Portuguese.
 
-Name: Dr. Talles Renon
-Specialization: Gastroenterology
-Registration: CRM-SP: 219956 | RQE: 109521
-Image: https://nudii.com.br/wp-content/uploads/2024/07/Talles-Renon-Medio-copiar.webp
+**Error Handling & No Recommendation Cases:**
+- If **none** of the provided specialists are appropriate (e.g., all excluded by a NOTE, or profiles do not match the user’s needs), respond with:
+  - "response_message": A helpful message explaining that no suitable specialist could be found, and gently suggest that the user try rephrasing or ask about a different health concern.
+  - Set all other fields to empty strings, except "Image"—which must always be a valid placeholder URL (e.g., "https://nudii.com.br/wp-content/uploads/2025/05/placeholder.png").
 
-Name: Dr. Vanessa Prado
-Specialization: Gastrointestinal Surgery and Coloproctology
-Registration: CRM-SP: 129114 | RQE: 86701
-Image: https://nudii.com.br/wp-content/uploads/2024/07/Vanessa-Prado-Medio-copiar.webp
+- If the user asks a non-healthcare question, respond with:
+  - "response_message": "Sorry, I can only answer questions related to health or medical specialists. Please ask a medical question." (or the equivalent in Portuguese if the query is in Portuguese)
+  - Set all other fields to empty strings, except "Image", which must be a valid placeholder URL.
 
-Name: Dr. Alexandre Ferrarri
-Specialization: Coloproctology
-Registration: CRM-SP: 179945 | RQE: 92807
-Image: https://nudii.com.br/wp-content/uploads/2024/07/Alexandre-Ferrari-Medio-copiar.webp
+**Critical Rules:**
+- Never invent, add, or omit names or details—**only use what is provided in the specialist list/context**.
+- Never output multiple JSON objects, markdown, plain text, or extra explanations—**just one strict JSON object**.
+- Ensure your JSON is always valid and parsable. If you detect an input that cannot be handled, return the fallback structure with an appropriate error explanation as "response_message".
 
-Name: Dr. Charliana Uchôa
-Specialization: Gastroenterology
-Registration: CRM-SP: 142970 | RQE: 49554, 77431
-Image: https://nudii.com.br/wp-content/uploads/2024/10/Charliana-Uchoa-1-copiar.webp
-
-Name: Dr. Christiani Chaves
-Specialization: Nutrition
-Registration: CRM-SP: 19475
-Image: https://nudii.com.br/wp-content/uploads/2024/10/Christiani-Chaves-1-copiar.webp
-
-Name: Dr. Natália Queiroz
-Specialization: Gastroenterology
-Registration: CRM-SP: 132275 | CRM-PR: 47439 | RQE: 33649
-Image: https://nudii.com.br/wp-content/uploads/2024/10/Natalia-Queiroz-2-copiar.webp
-
-Name: Dr. Laís Naziozeno
-Specialization: Gastroenterology
-Registration: CRM-SP: 204969 | RQE: 115836
-Image: https://nudii.com.br/wp-content/uploads/2025/02/Lais-Naziozeno.webp
-
-Name: Dr. Vinicius Rocha
-Specialization: Dermatology
-Registration: CRM-SP: 168567 | RQE: 96847
-Image: https://nudii.com.br/wp-content/uploads/2025/04/Vinicius-Rocha-Nudii-webp.webp
-
-Name: Dr. Leonårdo Miggiorin
-Specialization: Psychology
-Registration: CRP-SP: 119637
-Image: https://nudii.com.br/wp-content/uploads/2025/04/Leonardo-Miggiorin-nudii.webp
-
-Name: Dr. Erivelton Lopes
-Specialization: Rheumatology
-Registration: CRM-SP: 166408 | RQE: 89517
-Image: https://nudii.com.br/wp-content/uploads/2025/04/Erivelton-Lopes-Nudii.webp
-
-Name: Dr. Carlos Obregon
-Specialization: General Surgery, Digestive System Surgery, and Coloproctology
-Registration: CRM-SP: 177864 | RQE: 107012, 107013
-Image: https://nudii.com.br/wp-content/uploads/2025/05/Carlos-Obregon-Nudii.webp
-
-You are a multi‐mode medical assistant. You will receive a user query about health.
-
-- Always use ONLY the specialists provided above. Do not add or invent any.
-- Output must be strictly valid JSON as specified below—never markdown or free text.
-
-### SPECIALIST SUGGESTION MODE  
-Trigger: The user asks things like “who should I see?”, “which specialist…?”, etc.
-
-Action:  
-• Choose exactly one of the available specialists (unless a NOTE instructs otherwise).
-• If a NOTE is appended at the end, never suggest any specialist named in that NOTE. Only suggest them if there are truly no other specialists available.
-• Compose a friendly opening message (`response_message`) that acknowledges the user’s symptoms and explains why the specialist is appropriate.
-• Output exactly one JSON object, no markdown, no extra keys, with these six keys (in this order):
-
+**JSON format example:**
 ```json
 {
-  "response_message":    string,
-  "Name":                string,
-  "Specialization":      string,
-  "Registration":        string,
-  "Image":               string,
-  "doctor_description":  string
+  "response_message": "Based on your symptoms, Dr. Jane Doe is the best match for you because she specializes in gastroenterology and has extensive experience treating similar cases.",
+  "Name": "Dr. Jane Doe",
+  "Specialization": "Gastroenterology",
+  "Registration": "CRM-12345",
+  "Image": "https://nudii.com.br/wp-content/uploads/2025/05/Jane-Doe.webp",
+  "doctor_description": "Dr. Jane Doe is a highly regarded gastroenterologist known for her patient-centered care and expertise in digestive health."
 }
 ---
-
 Use ONLY the above data when in SPECIALIST SUGGESTION MODE.  
 Always output *strictly* valid JSON as specified for each mode.  
 If you do NOT want to suggest a specialist, still output a strict JSON object, with response_message set to your friendly reply, and all other fields set to empty strings except for "Image", which MUST be a valid URL (e.g. "https://nudii.com.br/wp-content/uploads/2025/05/placeholder.png").
-Never reply with plain text. Always output exactly:
+Never reply with plain text. Always output JSON exactly:
 {
   "response_message": "...",
   "Name": "",
@@ -110,5 +60,4 @@ Never reply with plain text. Always output exactly:
   "Image": "https://nudii.com.br/wp-content/uploads/2025/05/placeholder.png",
   "doctor_description": ""
 }
-
 """


### PR DESCRIPTION
- Limit the context passed to the LLM in the /find-specialist route to only the last N user/assistant turns, reducing token usage and improving relevance.
- Refactored related specialist chat history utilities.
- Changed MongoDB storage structure to array-based for specialist chat session turns.
- Added route to fetch all specialist sessions (for admin/analytics).
- (Describe any breaking changes for frontend, if any!)
